### PR TITLE
match uuid with repository name

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,5 @@
     "3.36"
   ], 
   "url": "https://github.com/BjoernDaase/noannoyance", 
-  "uuid": "noannoyance@daase.net"
+  "uuid": "noannoyance"
 }


### PR DESCRIPTION
Apparently the uuid has to match the folder name, as the module fails to load for me (gnome-shell 3.36.1 on Lunar Linux).

Avoids

```
gnome-shell[72726]: JS ERROR: Could not load extension noannoyance: Error: uuid "noannoyance@daase.net" from metadata.json does not match directory name "noannoyance"
```